### PR TITLE
Avoid C++14 features

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -27,7 +27,6 @@ Suggests:
     bench,
     rmarkdown,
     BiocStyle
-SystemRequirements: C++14
 VignetteBuilder: knitr
 URL: https://github.com/const-ae/sparseMatrixStats
 BugReports: https://github.com/const-ae/sparseMatrixStats/issues


### PR DESCRIPTION
Rewrite all the generic lambda functions in methods.cpp as Functor classes. This was suggested by Aaron Lun in https://github.com/const-ae/sparseMatrixStats/issues/18#issuecomment-796877576

The hope is that this should get rid of all the installation problems that people seem to encounter regularly.